### PR TITLE
Add a .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+vendor/bundle


### PR DESCRIPTION
The `vendor/bundle` dir should not be tracked under git.